### PR TITLE
Fix UnicodeEncodeError for unicode characters

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -113,7 +113,7 @@ def cli(opts, args):
         sys.exit(1)
 
     env = Environment(loader=FileSystemLoader(os.getcwd()))
-    sys.stdout.write(env.get_template(args[0]).render(data))
+    sys.stdout.write(env.get_template(args[0]).render(data).encode('utf-8'))
     sys.exit(0)
 
 


### PR DESCRIPTION
``` shell
$ jinja2 index.tmpl data.json
Traceback (most recent call last):
  File "~/.virtualenvs//bin/jinja2", line 9, in <module>
    load_entry_point('jinja2-cli==0.1.0', 'console_scripts', 'jinja2')()
  File "~/.virtualenvs//lib/python2.7/site-packages/jinja2cli/cli.py", line 142, in main
    cli(opts, args)
  File "~/.virtualenvs//lib/python2.7/site-packages/jinja2cli/cli.py", line 116, in cli
    sys.stdout.write(env.get_template(args[0]).render(data))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 536-559: ordinal not in range(128)
```
