### PR TITLE
add option to import os.environ to template data

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -130,6 +130,10 @@ def render(template_path, data, extensions):
         extensions=extensions,
         keep_trailing_newline=True,
     )
+
+    # Add environ global
+    env.globals['environ'] = os.environ.get
+
     output = env.get_template(os.path.basename(template_path)).render(data).encode('utf-8')
     return output
 


### PR DESCRIPTION
## What
Add option to import os.environ on to the template input data. 

## Why
Super handy when including jinja2-cli on docker containers, lets you run templates on start with out gross bash scripts.