### PR TITLE
add templating from environment file or environment variable

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -48,8 +48,10 @@ class MalformedToml(InvalidDataFormat):
 class MalformedXML(InvalidDataFormat):
     pass
 
+
 class MalformedENV(InvalidDataFormat):
     pass
+
 
 def get_format(fmt):
     try:
@@ -147,6 +149,7 @@ def _load_xml():
     import xmltodict
     return xmltodict.parse, xml.parsers.expat.ExpatError, MalformedXML
 
+
 def _load_env():
     return _parse_env, Exception, MalformedENV
 
@@ -155,7 +158,7 @@ def _parse_env(data):
     if data is os.environ:
         return data
     else:
-        return dict(env.split("=",1) for env in data.split('\n'))
+        return dict(env.split("=", 1) for env in data.split('\n'))
 
 
 # Global list of available format parsers on your system

--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -48,6 +48,8 @@ class MalformedToml(InvalidDataFormat):
 class MalformedXML(InvalidDataFormat):
     pass
 
+class MalformedENV(InvalidDataFormat):
+    pass
 
 def get_format(fmt):
     try:
@@ -145,6 +147,16 @@ def _load_xml():
     import xmltodict
     return xmltodict.parse, xml.parsers.expat.ExpatError, MalformedXML
 
+def _load_env():
+    return _parse_env, Exception, MalformedENV
+
+
+def _parse_env(data):
+    if data is os.environ:
+        return data
+    else:
+        return dict(env.split("=",1) for env in data.split('\n'))
+
 
 # Global list of available format parsers on your system
 # mapped to the callable/Exception to parse a string into a dict
@@ -156,6 +168,7 @@ formats = {
     'querystring': _load_querystring,
     'toml': _load_toml,
     'xml': _load_xml,
+    'env': _load_env
 }
 
 
@@ -192,7 +205,9 @@ def is_fd_alive(fd):
 def cli(opts, args):
     format = opts.format
     if args[1] == '-':
-        if is_fd_alive(sys.stdin):
+        if format == 'env':
+            data = os.environ
+        elif is_fd_alive(sys.stdin):
             data = sys.stdin.read()
         else:
             data = ''
@@ -227,6 +242,8 @@ def cli(opts, args):
                 raise InvalidDataFormat('toml: install toml to fix')
             if format == 'xml':
                 raise InvalidDataFormat('xml: install xmltodict to fix')
+            if format == 'env':
+                raise InvalidDataFormat('env: problem with the environment parsing')
             raise
         try:
             data = fn(data) or {}


### PR DESCRIPTION
this will enable to create config file easily for docker containers
I manually tested the code (passing via file, pipe and import the enviroment [via os.environ]. I tried made an unitest, without luck.
