### PR TITLE
override default jinja2 whitespace control

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -172,6 +172,8 @@ def render(template_path, data, extensions, strict=False):
         loader=FileSystemLoader(os.path.dirname(template_path)),
         extensions=extensions,
         keep_trailing_newline=True,
+        trim_blocks=True,
+        lstrip_blocks=True
     )
     if strict:
         from jinja2 import StrictUndefined


### PR DESCRIPTION
This would replace the default jinja2 behavior of preserving whitespace around content that has block tags on their own lines. (more info at http://jinja.pocoo.org/docs/dev/templates/#whitespace-control)

I'm in the process of using the cli to generate yaml config files and the default whitespace control makes formatting these much more difficult than it needs to be. If you feel like this shouldn't be the default behavior for the tool it could instead be added as a runtime param. 