### PR TITLE
Make keep_trailing_newline configurable, add trim_blocks and lstrip_blocks options

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -318,9 +318,9 @@ def main():
         help='Enable trim blocks option',
         dest='trim_blocks', action='store_true')
     parser.add_option(
-        '--keep-trailing-newline',
-        help='Enable jinja2 keep_trailing_newline option',
-        dest='keep_trailing_newline', action='store_true')
+        '--no-trailing-newline',
+        help='Disable jinja2 keep_trailing_newline option',
+        dest='keep_trailing_newline', action='store_false')
     parser.add_option(
         '--lstrip-blocks',
         help='Enable jinja2 lstrip_blocks option',

--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -167,7 +167,9 @@ import jinja2
 from jinja2 import Environment, FileSystemLoader
 
 
-def render(template_path, data, extensions, strict=False, keep_trailing_newline=True, trim_blocks=False, lstrip_blocks=False):
+def render(template_path, data, extensions, strict=False, keep_trailing_newline=True,
+           trim_blocks=False, lstrip_blocks=False):
+
     env = Environment(
         loader=FileSystemLoader(os.path.dirname(template_path)),
         extensions=extensions,
@@ -256,7 +258,8 @@ def cli(opts, args):
             sys.stderr.write('ERROR: unknown section. Exiting.')
             return 1
 
-    output = render(template_path, data, extensions, opts.strict, opts.keep_trailing_newline, opts.trim_blocks, opts.lstrip_blocks)
+    output = render(template_path, data, extensions, opts.strict, opts.keep_trailing_newline,
+                    opts.trim_blocks, opts.lstrip_blocks)
     if isinstance(output, binary_type):
         output = output.decode('utf-8')
     sys.stdout.write(output)

--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -167,11 +167,13 @@ import jinja2
 from jinja2 import Environment, FileSystemLoader
 
 
-def render(template_path, data, extensions, strict=False):
+def render(template_path, data, extensions, strict=False, keep_trailing_newline=True, trim_blocks=False, lstrip_blocks=False):
     env = Environment(
         loader=FileSystemLoader(os.path.dirname(template_path)),
         extensions=extensions,
-        keep_trailing_newline=True,
+        keep_trailing_newline=keep_trailing_newline,
+        trim_blocks=trim_blocks,
+        lstrip_blocks=lstrip_blocks,
     )
     if strict:
         from jinja2 import StrictUndefined
@@ -254,8 +256,7 @@ def cli(opts, args):
             sys.stderr.write('ERROR: unknown section. Exiting.')
             return 1
 
-    output = render(template_path, data, extensions, opts.strict)
-
+    output = render(template_path, data, extensions, opts.strict, opts.keep_trailing_newline, opts.trim_blocks, opts.lstrip_blocks)
     if isinstance(output, binary_type):
         output = output.decode('utf-8')
     sys.stdout.write(output)
@@ -312,6 +313,18 @@ def main():
         '--strict',
         help='Disallow undefined variables to be used within the template',
         dest='strict', action='store_true')
+    parser.add_option(
+        '--trim-blocks',
+        help='Enable trim blocks option',
+        dest='trim_blocks', action='store_true')
+    parser.add_option(
+        '--keep-trailing-newline',
+        help='Enable jinja2 keep_trailing_newline option',
+        dest='keep_trailing_newline', action='store_true')
+    parser.add_option(
+        '--lstrip-blocks',
+        help='Enable jinja2 lstrip_blocks option',
+        dest='lstrip_blocks', action='store_true')
     opts, args = parser.parse_args()
 
     # Dedupe list


### PR DESCRIPTION
Adding three new CLI flags which correspond to Jinja2's whitespace control options:

- no-trailing-newline - Disable keep_trailing_newline since default is enabled
- trim-blocks - Enable trim_blocks
- lstrip-blocks - Enable lstrip_blocks

