### PR TITLE
add smart loader for environment

### DIFF
--- a/tests/files/test_recursive_env/env/child_dir/sample.ini
+++ b/tests/files/test_recursive_env/env/child_dir/sample.ini
@@ -1,0 +1,2 @@
+[nested]
+delta = 33

--- a/tests/files/test_recursive_env/env/sample.ini
+++ b/tests/files/test_recursive_env/env/sample.ini
@@ -1,0 +1,2 @@
+[main]
+foo=bar

--- a/tests/files/test_recursive_env/env/second.ini
+++ b/tests/files/test_recursive_env/env/second.ini
@@ -1,0 +1,6 @@
+[extra]
+same=1
+
+
+[main]
+append=2

--- a/tests/test_recursive_env.py
+++ b/tests/test_recursive_env.py
@@ -1,0 +1,31 @@
+import os
+from jinja2cli import cli
+
+# change dir to tests directory to make relative paths possible
+os.chdir(os.path.dirname(os.path.realpath(__file__)))
+
+
+def test_use_plain_file_as_env():
+    # For backward capability
+    env_file = "./files/test_recursive_env/env/sample.ini"
+    data = cli._load_env_from_fs(env_file, False, 'auto')
+    assert data == {'main': {'foo': 'bar'}}
+
+
+def test_use_multiple_files_as_env():
+    """
+    Verify that we can load environment only in first layer
+    """
+    env_file = "./files/test_recursive_env/env/"
+    data = cli._load_env_from_fs(env_file, False, 'auto')
+    assert data == {'main': {'foo': 'bar', 'append': '2'}, 'extra': {'same': '1'}}
+
+
+def test_use_multiple_files_recursive_as_env():
+    """
+    Verify that we can load environment recursively
+    """
+    env_file = "./files/test_recursive_env/env/"
+    data = cli._load_env_from_fs(env_file, True, 'auto')
+    assert data == {'main': {'foo': 'bar', 'append': '2'},
+                    'extra': {'same': '1'}, 'nested': {'delta': '33'}}


### PR DESCRIPTION
Improve environment loader:

* can load variables from OS  environment (can be disabled by `--pure-env`)
* can load single file (as was)
* can load recursive all files in specified location if location is a dir
* can load all files in one layer if location is a dir and flag `--plain-env` specified

Why? Because for templates that depend of many variables is very useful keep different environment in different files. For example: common variables for all stages in `general.ini` and specific for `dev`, `prod` e.t.c