### PR TITLE
Fix StringIO import in Python3

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -82,7 +82,10 @@ def _load_ini():
         import configparser as ConfigParser
 
     def _parse_ini(data):
-        import StringIO
+        try:
+            from StringIO import StringIO
+        except ImportError:
+            from io import StringIO
 
         class MyConfigParser(ConfigParser.ConfigParser):
             def as_dict(self):
@@ -93,7 +96,7 @@ def _load_ini():
                 return d
 
         p = MyConfigParser()
-        p.readfp(StringIO.StringIO(data))
+        p.readfp(StringIO(data))
         return p.as_dict()
 
     return _parse_ini, ConfigParser.Error, MalformedINI


### PR DESCRIPTION
In environment with _Python 3.5.2_ an attempt to render template with **ini** as input data fails with the following traceback:

```
$ jinja2 cloud-config.jinja2 node.ini > result.yaml

Traceback (most recent call last):
  File "/usr/local/var/pyenv/versions/jinja2-tools/bin/jinja2", line 11, in <module>
    sys.exit(main())
  File "/usr/local/var/pyenv/versions/3.5.2/envs/jinja2-tools/lib/python3.5/site-packages/jinja2cli/cli.py", line 335, in main
    sys.exit(cli(opts, args))
  File "/usr/local/var/pyenv/versions/3.5.2/envs/jinja2-tools/lib/python3.5/site-packages/jinja2cli/cli.py", line 232, in cli
    data = fn(data) or {}
  File "/usr/local/var/pyenv/versions/3.5.2/envs/jinja2-tools/lib/python3.5/site-packages/jinja2cli/cli.py", line 85, in _parse_ini
    import StringIO
ImportError: No module named 'StringIO'
```

This PR fixes this issue.