### PR TITLE
add stdin detection for windows

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -212,6 +212,8 @@ def render(template_path, data, extensions, strict=False):
 
 
 def is_fd_alive(fd):
+    if os.name == 'nt':
+        return not os.isatty(fd.fileno())
     import select
     return bool(select.select([fd], [], [], 0)[0])
 


### PR DESCRIPTION
In PowerShell on Windows, using stdin throws an error: 
```
$ echo $data | jinja2 --format=json $template > out
-snip-
select.error: (10038, 'An operation was attempted on something that is not a socket')
```

I added some code that uses `os.isatty` to detect if stdin has data instead of `select.select` on Windows, which should resolve this.