### PR TITLE
Fix exception in python2 when output contains unicode characters

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -13,11 +13,6 @@ sys.path.insert(0, os.getcwd())
 
 PY3 = sys.version_info[0] == 3
 
-if PY3:
-    binary_type = bytes
-else:
-    binary_type = str
-
 
 class InvalidDataFormat(Exception):
     pass
@@ -208,7 +203,7 @@ def render(template_path, data, extensions, strict=False):
     env.globals['environ'] = os.environ.get
 
     output = env.get_template(os.path.basename(template_path)).render(data)
-    return output.encode('utf-8')
+    return output if PY3 else output.encode('utf-8')
 
 
 def is_fd_alive(fd):
@@ -284,9 +279,6 @@ def cli(opts, args):
             return 1
 
     output = render(template_path, data, extensions, opts.strict)
-
-    if isinstance(output, binary_type):
-        output = output.decode('utf-8')
     sys.stdout.write(output)
     return 0
 

--- a/tests/test_jinja2cli.py
+++ b/tests/test_jinja2cli.py
@@ -9,8 +9,6 @@ def test_relative_path():
     path = "./files/template.j2"
 
     output = cli.render(path, {"title": "Test"}, [])
-    if isinstance(output, cli.binary_type):
-        output = output.decode('utf-8')
     assert output == "Test"
 
 
@@ -19,6 +17,4 @@ def test_absolute_path():
     path = os.path.join(absolute_base_path, "files", "template.j2")
 
     output = cli.render(path, {"title": "Test"}, [])
-    if isinstance(output, cli.binary_type):
-        output = output.decode('utf-8')
     assert output == "Test"


### PR DESCRIPTION
In python2, the following error is shown when template output contains unicode characters:
```
Traceback (most recent call last):
  File "/usr/local/bin/jinja2", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/dist-packages/jinja2cli/cli.py", line 335, in main
    sys.exit(cli(opts, args))
  File "/usr/local/lib/python2.7/dist-packages/jinja2cli/cli.py", line 261, in cli
    sys.stdout.write(output)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xb5' in position 8979: ordinal not in range(128)
```

In python3, `str` supports unicode, and the `unicode` type was dropped. Therefore, unnecessary  encode should be avoided. I think it would be better to omit encoding then decoding when it comes to python3.

And more important, this pull request fix incorrectly decodes output from `utf-8` to `ascii` in python2, which causes the above mentioned error.