### PR TITLE
exclude tests from packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,13 +18,13 @@ tests_requires = ['pytest', 'flake8<3']
 
 setup(
     name='jinja2-cli',
-    version='0.7.0.dev0',
+    version='0.7.0.dev1',
     author='Matt Robenolt',
     author_email='matt@ydekproductions.com',
     url='https://github.com/mattrobenolt/jinja2-cli',
     description='A CLI interface to Jinja2',
     long_description=__doc__,
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     zip_safe=False,
     license='BSD',
     install_requires=install_requires,


### PR DESCRIPTION
currently, egg contains tests so the file structure looks like

```
.
└── local
    ├── bin
    │   └── jinja2
    └── lib
        └── python2.7
            └── dist-packages
                ├── jinja2cli
                │   ├── cli.py
                │   ├── cli.pyc
                │   ├── __init__.py
                │   └── __init__.pyc
                ├── jinja2_cli-0.7.0.dev1.egg-info
                │   ├── dependency_links.txt
                │   ├── entry_points.txt
                │   ├── not-zip-safe
                │   ├── PKG-INFO
                │   ├── requires.txt
                │   ├── SOURCES.txt
                │   └── top_level.txt
                └── tests
                    ├── __init__.py
                    ├── __init__.pyc
                    ├── test_jinja2cli.py
                    └── test_jinja2cli.pyc
```

This means that if this package installed with any other package that contains this bug, they will conflict (example when installing from rpm)

```
Transaction check error:
  file /usr/lib/python2.7/site-packages/tests/__init__.py from install of python-jinja2-cli-0.6.0-1.el7.noarch conflicts with file from package python-twilio-3.7.3-1.noarch
  file /usr/lib/python2.7/site-packages/tests/__init__.pyc from install of python-jinja2-cli-0.6.0-1.el7.noarch conflicts with file from package python-twilio-3.7.3-1.noarch
```

with this change, folder structure becomes

```
.
├── bin
│   └── jinja2
└── lib
    └── python2.7
        └── dist-packages
            ├── jinja2cli
            │   ├── cli.py
            │   ├── cli.pyc
            │   ├── __init__.py
            │   └── __init__.pyc
            └── jinja2_cli-0.7.0.dev1.egg-info
                ├── dependency_links.txt
                ├── entry_points.txt
                ├── not-zip-safe
                ├── PKG-INFO
                ├── requires.txt
                ├── SOURCES.txt
                └── top_level.txt
```
