### PR TITLE
Fix to build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install: pip install -e .[yaml,toml,tests]
 
 script:
   - py.test -v
-  - flake8 jinja2cli tests
+  - flake8 jinja2cli tests --builtins="unicode"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/mattrobenolt/jinja2-cli.svg?branch=master)](https://travis-ci.org/mattrobenolt/jinja2-cli)
+
 # $ jinja2
 A CLI interface to Jinja2
 ```

--- a/tests/test_jinja2cli.py
+++ b/tests/test_jinja2cli.py
@@ -9,9 +9,9 @@ def test_relative_path():
     path = "./files/template.j2"
 
     output = cli.render(path, {"title": "Test"}, [])
-    if isinstance(output, cli.binary_type):
+    if isinstance(output, cli.text_type):
         output = output.decode('utf-8')
-    assert output == "Test"
+    assert output == b"Test"
 
 
 def test_absolute_path():
@@ -19,6 +19,6 @@ def test_absolute_path():
     path = os.path.join(absolute_base_path, "files", "template.j2")
 
     output = cli.render(path, {"title": "Test"}, [])
-    if isinstance(output, cli.binary_type):
+    if isinstance(output, cli.text_type):
         output = output.decode('utf-8')
-    assert output == "Test"
+    assert output == b"Test"


### PR DESCRIPTION
I'd like to PR a fix.

The last commit caused some build failures on travis-ci:
https://travis-ci.org/mattrobenolt/jinja2-cli/builds/269663691?utm_source=github_status&utm_medium=notification

The proposed changes below fix these issues:
https://travis-ci.org/ralexander-phi/jinja2-cli/builds/273153997?utm_source=github_status&utm_medium=notification


Commit Message-
Problem: python3 doesn't have unicode built-in function, flake8 logs an error even though the interpreter won't reach that code
Fix: Tell flake8 to assume unicode is built-in

Problem: tests need update for unicode fixes
Fix: Update tests

Additions:
- Add travis-ci build status to README