### PR TITLE
Ability to overwrite template variables in section

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -272,8 +272,6 @@ def cli(opts, args):
             ext = 'jinja2.ext.' + ext
         extensions.append(ext)
 
-    data.update(parse_kv_string(opts.D or []))
-
     # Use only a specific section if needed
     if opts.section:
         section = opts.section
@@ -282,6 +280,7 @@ def cli(opts, args):
         else:
             sys.stderr.write('ERROR: unknown section. Exiting.')
             return 1
+    data.update(parse_kv_string(opts.D or []))
 
     output = render(template_path, data, extensions, opts.strict)
 


### PR DESCRIPTION
Currently `jinja2-cli` works differently if values for variables are coming from a section or base on a whole file. For example you can't overwrite variables defined in section using cli option `-D`.
This small fix should resolve the issue.