### PR TITLE
sample.sh: use idiomatic yaml, show how to set more than just a list

### DIFF
--- a/samples/sample.sh
+++ b/samples/sample.sh
@@ -7,14 +7,17 @@ list2yml() {
   local name
   name=$1
   shift
-  echo "'$name': ["
+  echo "$name:"
   for item
   do
-     echo "'$item',"
+     echo "- $item"
   done
-  echo ']'
+}
+
+val2yml() {
+  echo "$1: $2"
 }
 
 ITEMS="apple banana cherry"
 
-list2yml items $ITEMS | jinja2 sample.jinja2
+(list2yml items $ITEMS; val2yml foo true) | jinja2 sample.jinja2


### PR DESCRIPTION
- list2yaml's output no longer makes yaml parsers (human or otherwise) barf
- sample.sh now exercises the 'foo' variable sensed by sample.jinja2

(The yaml parser that exploded on the old list2yaml is the one in gomatic/renderizer.
I'm hedging my bets :-) )
