### PR TITLE
Allow to run as a single file script

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """
 jinja2-cli
 ==========
@@ -354,9 +356,11 @@ class LazyOptionParser(OptionParser):
 
     def get_version(self):
         from jinja2 import __version__ as jinja_version
-        from jinja2cli import __version__
-
-        return "jinja2-cli v%s\n - Jinja2 v%s" % (__version__, jinja_version)
+        try:
+            from jinja2cli import __version__
+            return "jinja2-cli v%s\n - Jinja2 v%s" % (__version__, jinja_version)
+        except ModuleNotFoundError:
+            return "jinja2-cli\n - Jinja2 v%s" % (jinja_version)
 
 
 def main():


### PR DESCRIPTION
Hi.

I love your tool because I can use it as a single file script in an environment without `pip` and the Internet access and I'm not forced to package it into binary archive. Dead simple deployment so it is very devops friendly.

I use only this small improvement that `cli.py` works even if there is no other file in the system (`__init__.py` in this case). Ok, a hashbang at top is quite useful too.

Then you can decide if you want to install the project standard way (`pip install ...`) or just upload this one file to the target host (`scp cli.py host:/usr/local/bin/jinja2-cli`).
