### PR TITLE
Support for overriding -D parameters with dot notation

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -321,7 +321,13 @@ def parse_kv_string(pairs):
     dict_ = {}
     for pair in pairs:
         k, v = pair.split("=", 1)
-        dict_[force_text(k)] = force_text(v)
+        k=force_text(k)
+        v=force_text(v)
+        aux=dict()
+        for i in reversed(k.split('.')):
+            aux={i:v}
+            v=aux
+        dict_.update(aux)
     return dict_
 
 


### PR DESCRIPTION
New Feature:
 - Feature request: parse -D parameters with dot notation #82

Example:
 - Command:
```
bash$ python3 ./jinja2cli/cli.py \
-D "name=Alvaro Torres Cogollo" \
-D "data.email=atorrescogollo@gmail.com" \
<( # <====================== Template ======================>
cat << 'EOF'
=================
MY PERSONAL INFO:
=================
Name : {{ name }}
Email: {{ data.email }}
EOF
) \
<( # <====================== Source data ====================>
cat << 'EOF'
name : Some Name
data :
    email : Some Email
EOF
) \
--format=yaml
````
 - Output
```
MY PERSONAL INFO:
=================
Name : Alvaro Torres Cogollo
Email: atorrescogollo@gmail.com
```