### PR TITLE
Add LaTeX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Options:
                         Use only this section from the configuration
   --strict              Disallow undefined variables to be used within the
                         template
+  --latex               Use markers that are compatible with LaTeX
 ```
 
 ## Optional YAML support
@@ -43,6 +44,30 @@ If `xmltodict` is present, you can use XML as an input data source.
 
 `$ pip install jinja2-cli[xml]`
 
+## LaTeX support
+The default markers used by Jinja2 are incompatible with LaTeX, as explained
+in blog posts by [Brad Erickson] and [Arthur Miller]. The option `--latex`
+changes the default markers to the following ones by passing , which are compatible with
+LaTeX and do not require any special escaping.
+
+| Default markers       | LaTeX mode        | Jinja2 env settings     |
+| :-------------------- | :---------------- | :---------------------- |
+| `{%` ... `%}`         | `\BLOCK{` ... `}` | `block_*_string`        |
+| `{{` ... `}}`         |  `\VAR{`... `}`   | `variable_*_string`     |
+| `{#` ... `#}`         |  `\#{` ... `}`    | `comment_*_string`      |
+|	*disabled by default* | `%%`              | `line_statement_prefix` |
+|	*disabled by default* | `%#`              | `line_comment_prefix`   |
+
+In addition, the option `trim_blocks` is set to true, and `autoescape` set to
+false.
+
+Example usage:
+```
+jinja2 --latex samples/sample.tex samples/sample.json
+```
+
+[Brad Erickson]: http://eosrei.net/articles/2015/11/latex-templates-python-and-jinja2-generate-pdfs
+[Arthur Miller]: https://miller-blog.com/latex-with-jinja2/
 ## TODO
  * Variable inheritance and overrides
   * Tests!

--- a/samples/sample.tex
+++ b/samples/sample.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+
+\begin{document}
+
+\begin{itemize}
+\BLOCK{ for i in items }
+  \item \VAR{i}
+\BLOCK{ endfor }
+\end{itemize}
+
+\end{document}


### PR DESCRIPTION
The default markers used by Jinja2 conflict with LaTeX commands. This PR adds support to process LaTeX files with jinja2-cli.

The option `--latex` replaces the default Jinja2 markers with ones that are are compatible with LaTeX. The alternative markers are documented in the README, and `samples/sample.tex` shows the usage.