### PR TITLE
Support jinja2==3.1.0

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -385,7 +385,7 @@ def main():
         help="extra jinja2 extensions to load",
         dest="extensions",
         action="append",
-        default=["do", "with_", "autoescape", "loopcontrols"],
+        default=["do", "loopcontrols"],
     )
     parser.add_option(
         "-D",


### PR DESCRIPTION
https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0:
WithExtension and AutoEscapeExtension are built-in now.

Now jinja2-cli doesn't work:
```
Traceback (most recent call last):
  File "/tmp/.local/bin/jinja2", line 8, in <module>
    sys.exit(main())
  File "/tmp/.local/lib/python3.9/site-packages/jinja2cli/cli.py", line 335, in main
    sys.exit(cli(opts, args))
  File "/tmp/.local/lib/python3.9/site-packages/jinja2cli/cli.py", line 257, in cli
    output = render(template_path, data, extensions, opts.strict)
  File "/tmp/.local/lib/python3.9/site-packages/jinja2cli/cli.py", line 171, in render
    env = Environment(
  File "/tmp/.local/lib/python3.9/site-packages/jinja2/environment.py", line 363, in __init__
    self.extensions = load_extensions(self, extensions)
  File "/tmp/.local/lib/python3.9/site-packages/jinja2/environment.py", line 117, in load_extensions
    extension = t.cast(t.Type["Extension"], import_string(extension))
  File "/tmp/.local/lib/python3.9/site-packages/jinja2/utils.py", line 1[49](https://gitlab.semrush.net/Cream-team/SWA/-/jobs/8292982#L49), in import_string
    return getattr(__import__(module, None, None, [obj]), obj)
AttributeError: module 'jinja2.ext' has no attribute 'with_'
```