### PR TITLE
Support jinja2 3.1

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -150,7 +150,7 @@ def _load_querystring():
         import urllib.parse as urlparse
 
     def _parse_qs(data):
-        """ Extend urlparse to allow objects in dot syntax.
+        """Extend urlparse to allow objects in dot syntax.
 
         >>> _parse_qs('user.first_name=Matt&user.last_name=Robenolt')
         {'user': {'first_name': 'Matt', 'last_name': 'Robenolt'}}
@@ -221,7 +221,23 @@ formats = {
 
 
 def render(template_path, data, extensions, strict=False):
-    from jinja2 import Environment, FileSystemLoader, StrictUndefined
+    from jinja2 import (
+        __version__ as jinja_version,
+        Environment,
+        FileSystemLoader,
+        StrictUndefined,
+    )
+
+    # Starting with jinja2 3.1, `with_` and `autoescape` are no longer
+    # able to be imported, but since they were default, let's stub them back
+    # in implicitly for older versions.
+    # We also don't track any lower bounds on jinja2 as a dependency, so
+    # it's not easily safe to know it's included by default either.
+    if tuple(jinja_version.split(".", 2)) < ("3", "1"):
+        for ext in "with_", "autoescape":
+            ext = "jinja2.ext." + ext
+            if ext not in extensions:
+                extensions.append(ext)
 
     env = Environment(
         loader=FileSystemLoader(os.path.dirname(template_path)),
@@ -287,7 +303,7 @@ def cli(opts, args):
         try:
             data = fn(data) or {}
         except except_exc:
-            raise raise_exc(u"%s ..." % data[:60])
+            raise raise_exc("%s ..." % data[:60])
     else:
         data = {}
 
@@ -385,7 +401,7 @@ def main():
         help="extra jinja2 extensions to load",
         dest="extensions",
         action="append",
-        default=["do", "with_", "autoescape", "loopcontrols"],
+        default=["do", "loopcontrols"],
     )
     parser.add_option(
         "-D",


### PR DESCRIPTION
Since Jinja2 3.1, `while_` and `autoescape` have been removed. They've
been included in stdlib for a while and didn't need to be included.

Unfortuantely we don't pin to any lower or upper bounds of jinja2, so
the best/fastest option is to just version detect and include by default
if less than 3.1.

Fixes #100
Fixes #101