### PR TITLE
Allow explicitly setting `None`

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -370,11 +370,12 @@ def cli(opts, args):
 def parse_kv_string(pairs):
     dict_ = {}
     for pair in pairs:
-        if "=" not in pair:
-            dict_[force_text(pair)] = None
-            continue
-        k, v = pair.split("=", 1)
-        dict_[force_text(k)] = force_text(v)
+        pair = force_text(pair)
+        try:
+            k, v = pair.split("=", 1)
+        except ValueError:
+            k, v = pair, None
+        dict_[k] = v
     return dict_
 
 

--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -370,6 +370,9 @@ def cli(opts, args):
 def parse_kv_string(pairs):
     dict_ = {}
     for pair in pairs:
+        if "=" not in pair:
+            dict_[force_text(pair)] = None
+            continue
         k, v = pair.split("=", 1)
         dict_[force_text(k)] = force_text(v)
     return dict_


### PR DESCRIPTION
The current implementation seems not supporting `None` via `-D`.

Example template file:
```jinja2
VARIABLE: {{ VARIABLE }}
class: {{ VARIABLE.__class__ }}

{% if VARIABLE is none -%}
Is none.
{%- else -%}
Is not none.
{%- endif %}

{% if VARIABLE == "" -%}
Is empty string.
{%- else -%}
Is not empty string.
{%- endif %}
```

This pull requests allows explicitly setting `None` by `-D VARIABLE`.

```console
$ jinja2 ./sample.jinja2 -D VARIABLE
VARIABLE: None
class: <class 'NoneType'>

Is none.

Is not empty string.
```

<details>
<summary>Current behavior details</summary>

- No `-D`

```console
$ jinja2 ./sample.jinja2
VARIABLE:
class: <class 'jinja2.runtime.Undefined'>

Is not none.

Is not empty string.
```

- `-D VARIABLE=None`

```console
$ jinja2 ./sample.jinja2 -D VARIABLE=
VARIABLE:
class: <class 'str'>

Is not none.

Is empty string.
```

- `-D VARIABLE=None`

```console
$ jinja2 ./sample.jinja2 -D VARIABLE=None
VARIABLE: None
class: <class 'str'>

Is not none.

Is not empty string.
```

- `-D VARIABLE`

```console
$ jinja2 ./sample.jinja2 -D VARIABLE
Traceback (most recent call last):
  File "/home/kenji/.local/bin/jinja2", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/kenji/.local/pipx/venvs/jinja2-cli/lib/python3.11/site-packages/jinja2cli/cli.py", line 449, in main
    sys.exit(cli(opts, args))
             ^^^^^^^^^^^^^^^
  File "/home/kenji/.local/pipx/venvs/jinja2-cli/lib/python3.11/site-packages/jinja2cli/cli.py", line 327, in cli
    data.update(parse_kv_string(opts.D or []))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kenji/.local/pipx/venvs/jinja2-cli/lib/python3.11/site-packages/jinja2cli/cli.py", line 347, in parse_kv_string
    k, v = pair.split("=", 1)
    ^^^^
ValueError: not enough values to unpack (expected 2, got 1)
```
</details>