### PR TITLE
Add --trim-blocks and --lstrip-blocks

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -242,7 +242,7 @@ formats = {
 }
 
 
-def render(template_path, data, extensions, strict=False):
+def render(template_path, data, extensions, strict=False, trim_blocks=False, lstrip_blocks=False):
     from jinja2 import (
         __version__ as jinja_version,
         Environment,
@@ -265,6 +265,8 @@ def render(template_path, data, extensions, strict=False):
         loader=FileSystemLoader(os.path.dirname(template_path)),
         extensions=extensions,
         keep_trailing_newline=True,
+        trim_blocks=trim_blocks,
+        lstrip_blocks=lstrip_blocks,
     )
     if strict:
         env.undefined = StrictUndefined
@@ -362,7 +364,7 @@ def cli(opts, args):
 
         out = codecs.getwriter("utf8")(out)
 
-    out.write(render(template_path, data, extensions, opts.strict))
+    out.write(render(template_path, data, extensions, opts.strict, opts.trim_blocks, opts.lstrip_blocks))
     out.flush()
     return 0
 
@@ -456,6 +458,18 @@ def main():
         dest="outfile",
         metavar="FILE",
         action="store",
+    )
+    parser.add_option(
+        "--trim-blocks",
+        help="Trim first newline after a block",
+        dest="trim_blocks",
+        action="store_true",
+    )
+    parser.add_option(
+        "--lstrip-blocks",
+        help="Strip first newline after a block",
+        dest="lstrip_blocks",
+        action="store_true",
     )
     opts, args = parser.parse_args()
 


### PR DESCRIPTION
It's helpful if we can use `trim_blocks` and `lstrip_blocks` rendering options.

Explaining with a sample in https://ttl255.com/jinja2-tutorial-part-3-whitespace-control/.

sample.jinja2:
```jinja2
{% for iname, idata in interfaces.items() %}
interface {{ iname }}
 description {{ idata.description }}
  {% if idata.ipv4_address is defined %}
 ip address {{ idata.ipv4_address }}
  {% endif %}
{% endfor %}
```

input.yaml:
```yaml
interfaces:
  Ethernet1:
    description: capture-port
  Ethernet2:
    description: leaf01-eth51
    ipv4_address: 10.50.0.0/31
```

- No option

```console
$ jinja2 sample.jinja2 input.yaml

interface Ethernet1
 description capture-port


interface Ethernet2
 description leaf01-eth51

 ip address 10.50.0.0/31



```

- Only `--trim-blocks`

```console
jinja2 sample.jinja2 input.yaml --trim-blocks
interface Ethernet1
 description capture-port
  interface Ethernet2
 description leaf01-eth51
   ip address 10.50.0.0/31
  ⏎
```

- Both `--trim-blocks` and `--lstrip-blocks`

```console
$ jinja2 sample.jinja2 input.yaml --trim-blocks --lstrip-blocks
interface Ethernet1
 description capture-port
interface Ethernet2
 description leaf01-eth51
 ip address 10.50.0.0/31
```