### PR TITLE
feat(cli): add possibility to define data.json-path via env-var

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ $ jinja2 helloworld.tmpl data.json --format=json
 $ cat data.json | jinja2 helloworld.tmpl
 $ curl -s http://httpbin.org/ip | jinja2 helloip.tmpl
 $ curl -s http://httpbin.org/ip | jinja2 helloip.tmpl > helloip.html
+$ JINJA_INPUT_DATA_PATH=payload.json jinja2 helloworld.tmpl
 ```
 
 ## Install
@@ -26,6 +27,15 @@ Options:
                         Use only this section from the configuration
   --strict              Disallow undefined variables to be used within the
                         template
+```
+
+## Reading input data path from environment variable
+
+Set the value of the environment variable `JINJA_INPUT_DATA_PATH` to the path to your input data.
+This way the input data get read from there and you don't have to specify it on the command line:
+
+```
+JINJA_INPUT_DATA_PATH=payload.json jinja2 helloworld.tmpl
 ```
 
 ## Optional YAML support

--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -291,7 +291,7 @@ def is_fd_alive(fd):
 def cli(opts, args):
     template_path, data = args
     format = opts.format
-    if data in ("-", ""):
+    if data in ("-", "") and not "JINJA_INPUT_DATA_PATH" in os.environ:
         if data == "-" or (data == "" and is_fd_alive(sys.stdin)):
             data = sys.stdin.read()
         if format == "auto":
@@ -302,7 +302,7 @@ def cli(opts, args):
             else:
                 format = "json"
     else:
-        path = os.path.join(os.getcwd(), os.path.expanduser(data))
+        path = os.path.join(os.environ["JINJA_INPUT_DATA_PATH"]) if os.environ["JINJA_INPUT_DATA_PATH"] else os.path.join(os.getcwd(), os.path.expanduser(data))
         if format == "auto":
             ext = os.path.splitext(path)[1][1:]
             if has_format(ext):


### PR DESCRIPTION
When you use the jinja-cli in scripting, it's easier to define the env-var once and then use it all the time.