### PR TITLE
Allow multiple variable files as argument

### DIFF
--- a/samples/sample.yaml
+++ b/samples/sample.yaml
@@ -1,0 +1,1 @@
+foo: foo_content


### PR DESCRIPTION
This allows specifying multiple variables as arguments to the CLI, latter files potentially overwriting variables from prior files. If format is set to auto the format detection will run for every file.

Example:
`jinja2-cli samples/sample.jinja2 samples/sample.json samples/sample.yaml`