### PR TITLE
Support for specifying which Undefined Type to use

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -16,6 +16,16 @@ from collections.abc import Iterable, Iterator, Sequence
 from types import ModuleType
 from typing import IO, Any, Callable, Tuple, Type, Union
 
+import jinja2 as _jinja2
+
+# Discover available Undefined classes from jinja2 at import time.
+# Excludes UndefinedError (an exception, not an Undefined class).
+UNDEFINED_CLASSES: dict[str, Type[Any]] = {
+    name: getattr(_jinja2, name)
+    for name in dir(_jinja2)
+    if name.endswith("Undefined") and name != "UndefinedError"
+}
+
 
 class InvalidDataFormat(Exception):
     pass
@@ -328,6 +338,7 @@ def render(
     extensions: list[ExtensionSpec],
     filters: list[str] | None = None,
     strict: bool = False,
+    undefined: str | None = None,
     trim_blocks: bool = False,
     lstrip_blocks: bool = False,
     autoescape: bool = False,
@@ -347,7 +358,6 @@ def render(
     from jinja2 import (
         Environment,
         FileSystemLoader,
-        StrictUndefined,
         UndefinedError,
     )
 
@@ -387,7 +397,9 @@ def render(
 
     env = Environment(**env_kwargs)
     if strict:
-        env.undefined = StrictUndefined
+        env.undefined = UNDEFINED_CLASSES["StrictUndefined"]
+    elif undefined is not None:
+        env.undefined = UNDEFINED_CLASSES[undefined]
 
     # Load custom filters
     if filters:
@@ -467,6 +479,11 @@ def resolve_extension(extension: ExtensionSpec, base_dir: str) -> ExtensionSpec:
 def cli(opts: argparse.Namespace, args: Sequence[str]) -> int:
     template_string: str | None = None
     template_path: str | None = None
+
+    if opts.strict and opts.undefined is not None:
+        raise InvalidUsage(
+            "cannot use --strict and --undefined together; use --undefined=StrictUndefined instead"
+        )
 
     if opts.stream:
         # Stream mode: read template from stdin, all args are data files
@@ -567,6 +584,7 @@ def cli(opts: argparse.Namespace, args: Sequence[str]) -> int:
         extensions,
         filters=opts.filters,
         strict=opts.strict,
+        undefined=opts.undefined,
         trim_blocks=opts.trim_blocks,
         lstrip_blocks=opts.lstrip_blocks,
         autoescape=opts.autoescape,
@@ -710,6 +728,17 @@ def run() -> int:
         help="Disallow undefined variables to be used within the template",
         dest="strict",
         action="store_true",
+    )
+    parser.add_argument(
+        "--undefined",
+        help=(
+            "Undefined class to use for variables not found in the context. "
+            "Choices: " + ", ".join(sorted(UNDEFINED_CLASSES))
+        ),
+        dest="undefined",
+        choices=sorted(UNDEFINED_CLASSES),
+        default=None,
+        metavar="UNDEFINED",
     )
     parser.add_argument(
         "-o",

--- a/tests/test_jinja2cli.py
+++ b/tests/test_jinja2cli.py
@@ -259,3 +259,79 @@ class TestParseKvString:
         """Test adding to existing nested path"""
         result = cli.parse_kv_string(["foo.bar=1", "foo.baz=2"])
         assert result == {"foo": {"bar": "1", "baz": "2"}}
+
+
+class TestUndefinedOption:
+    """Tests for the --undefined option and render() undefined parameter."""
+
+    def test_default_undefined_raises_on_chained_access(self, tmp_path):
+        """Default Undefined raises UndefinedError on chained attribute access."""
+        from jinja2 import UndefinedError
+
+        template = tmp_path / "t.j2"
+        template.write_text("{{ foo.bar }}")
+        with pytest.raises(UndefinedError):
+            cli.render(str(template), {}, [])
+
+    def test_chainable_undefined_allows_chained_access(self, tmp_path):
+        """ChainableUndefined returns empty string for chained attribute access."""
+        template = tmp_path / "t.j2"
+        template.write_text("{{ foo.bar }}")
+        output = cli.render(str(template), {}, [], undefined="ChainableUndefined")
+        assert output == ""
+
+    def test_chainable_undefined_with_default_filter(self, tmp_path):
+        """ChainableUndefined works with the default filter on chained access."""
+        template = tmp_path / "t.j2"
+        template.write_text("{{ foo.bar | default('fallback') }}")
+        output = cli.render(str(template), {}, [], undefined="ChainableUndefined")
+        assert output == "fallback"
+
+    def test_strict_undefined_raises(self, tmp_path):
+        """strict=True (StrictUndefined) raises UndefinedError."""
+        from jinja2 import UndefinedError
+
+        template = tmp_path / "t.j2"
+        template.write_text("{{ foo }}")
+        with pytest.raises(UndefinedError):
+            cli.render(str(template), {}, [], strict=True)
+
+    def test_undefined_strict_class_raises(self, tmp_path):
+        """undefined='StrictUndefined' raises UndefinedError."""
+        from jinja2 import UndefinedError
+
+        template = tmp_path / "t.j2"
+        template.write_text("{{ foo }}")
+        with pytest.raises(UndefinedError):
+            cli.render(str(template), {}, [], undefined="StrictUndefined")
+
+    def test_debug_undefined(self, tmp_path):
+        """DebugUndefined renders a debug string instead of raising."""
+        template = tmp_path / "t.j2"
+        template.write_text("{{ foo }}")
+        output = cli.render(str(template), {}, [], undefined="DebugUndefined")
+        assert "foo" in output
+
+    def test_strict_and_undefined_conflict_raises(self, tmp_path, monkeypatch):
+        """Using both --strict and --undefined raises InvalidUsage."""
+        template = tmp_path / "t.j2"
+        template.write_text("{{ foo }}")
+        data = tmp_path / "data.json"
+        data.write_text("{}")
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["jinja2", "--strict", "--undefined=ChainableUndefined", str(template), str(data)],
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+        assert exc_info.value.code == 1
+
+    def test_undefined_classes_dict_contains_expected_classes(self):
+        """UNDEFINED_CLASSES contains the standard Jinja2 Undefined classes."""
+        assert "Undefined" in cli.UNDEFINED_CLASSES
+        assert "ChainableUndefined" in cli.UNDEFINED_CLASSES
+        assert "DebugUndefined" in cli.UNDEFINED_CLASSES
+        assert "StrictUndefined" in cli.UNDEFINED_CLASSES
+        assert "UndefinedError" not in cli.UNDEFINED_CLASSES


### PR DESCRIPTION
Currently only the default `Undefined` and `StrictUndefined` are supported, but I needed `ChainableUndefined` in my usecase for parsing deployment templates normally run with ansible.

This PR adds the `--undefined` option to allow you to select which behaviour you want for your undefineds.

Minimal example:

test_template.yml
```yaml
---
apiVersion: test
spec:
  env:
    - name: ENVIRONMENT_OPENTELEMETRY_SDK_DISABLED
      value: "{{ opentelemetry.sdk.disabled | default(true) }}"
    - name: ENVIRONMENT_OPENTELEMETRY_EXPORTER_OTLP_ENDPOINT
      value: "{{ opentelemetry.exporter.otlp.endpoint | default('') }}"
    - name: APP_NAME
      value: "{{ app_name }}"
```

test_vars.yml
```yaml
app_name: test-app
```
Currently this fails
```bash
jinja2 test_template.yml test_vars.yml
UndefinedError: 'opentelemetry' is undefined
```

With this PR it succeds
```bash
python3 -m jinja2cli test_template.yml test_vars.yml -f yaml --undefined=ChainableUndefined
---
apiVersion: test
spec:
  env:
    - name: ENVIRONMENT_OPENTELEMETRY_SDK_DISABLED
      value: "True"
    - name: ENVIRONMENT_OPENTELEMETRY_EXPORTER_OTLP_ENDPOINT
      value: ""
    - name: APP_NAME
      value: "test-app"
```