### PR TITLE
Allows for multiple -s|--section options

### DIFF
--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -553,11 +553,12 @@ def cli(opts: argparse.Namespace, args: Sequence[str]) -> int:
 
     # Use only a specific section if needed
     if opts.section:
-        section = opts.section
-        if section in data:
-            data = data[section]
-        else:
-            raise InvalidUsage(f"unknown section: {section}")
+        section_set = set(opts.section)
+        data = {k: v for k, v in data.items() if k in section_set}
+        data_keys = set(data.keys())
+        if data_keys != section_set:
+            missing = section_set - data_keys
+            raise InvalidUsage(f"unknown sections: {', '.join(missing)}" if (len(missing) > 1) else f"unknown section: {''.join(missing)}")
 
     deep_merge(data, parse_kv_string(opts.D or []))
 
@@ -702,8 +703,9 @@ def run() -> int:
     parser.add_argument(
         "-s",
         "--section",
-        help="Use only this section from the configuration",
+        help="Use only this section from the configuration. Can be used multiple times.",
         dest="section",
+        action="append",
     )
     parser.add_argument(
         "--strict",

--- a/jinja2cli/cli.py
+++ b/jinja2cli/cli.py
@@ -551,14 +551,22 @@ def cli(opts: argparse.Namespace, args: Sequence[str]) -> int:
             ext = f"jinja2.ext.{ext}"
         extensions.append(resolve_extension(ext, os.getcwd()))
 
-    # Use only a specific section if needed
-    if opts.section:
-        section_set = set(opts.section)
-        data = {k: v for k, v in data.items() if k in section_set}
-        data_keys = set(data.keys())
-        if data_keys != section_set:
-            missing = section_set - data_keys
-            raise InvalidUsage(f"unknown sections: {', '.join(missing)}" if (len(missing) > 1) else f"unknown section: {''.join(missing)}")
+    # Use specified sections if needed
+    if len(opts.section) == 1:
+        section = opts.section[0]
+        if section in data:
+            data = data[section]
+        else:
+            raise InvalidUsage(f"unknown section: {section}")
+    elif len(opts.section) > 1:
+        # for multiple values, all must be iterables
+        merged_data = {}
+        for k, v in data.items():
+            if k in opts.section:
+                if not isinstance(v, Iterable):
+                    raise InvalidUsage(f"invalid section: {k}: must be iterable")
+                merged_data.update(v)
+        data = merged_data
 
     deep_merge(data, parse_kv_string(opts.D or []))
 


### PR DESCRIPTION
This PR adds support for multiple `-s|--section` options to be provided in the command line.
This allows for more than one section being filtered for the data context.